### PR TITLE
Add default PR template for the org

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,5 @@
 <!-- Describe the reasons for the changes (WHY), and summarize the changes in behavior (WHAT). -->
 <!-- What steps you've taken to check your work? Include specific commands and outputs. No vague test plans like "ci passed" or "tested on my machine" -->
+<!-- The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->
+
+Signed-off-by: Your Name <your.email@example.com>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,2 @@
-## Summary:
 <!-- Describe the reasons for the changes (WHY), and summarize the changes in behavior (WHAT). -->
-
-## Reproducible Test Plan:
-<!-- What steps you've taken to check your work? Include specific commands and outputs. No vague plans like "ci passed" or "tested on my machine" -->
+<!-- What steps you've taken to check your work? Include specific commands and outputs. No vague test plans like "ci passed" or "tested on my machine" -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Summary:
+<!-- Describe the reasons for the changes (WHY), and summarize the changes in behavior (WHAT). -->
+
+## Reproducible Test Plan:
+<!-- What steps you've taken to check your work? Include specific commands and outputs. No vagues plans like "ci passed" or "tested on my machine" -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
-<!-- Describe the reasons for the changes (WHY), and summarize the changes in behavior (WHAT). -->
-<!-- What steps you've taken to check your work? Include specific commands and outputs. No vague test plans like "ci passed" or "tested on my machine" -->
-<!-- The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->
+<!-- Delete this notice and replace it with your PR description:
+Describe the reasons for the changes (WHY), and summarize the changes in behavior (WHAT).
+What steps you've taken to check your work? Include specific commands and outputs. No vague test plans like "ci passed" or "tested on my machine".
+The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->
 
 Signed-off-by: Your Name <your.email@example.com>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@
 <!-- Describe the reasons for the changes (WHY), and summarize the changes in behavior (WHAT). -->
 
 ## Reproducible Test Plan:
-<!-- What steps you've taken to check your work? Include specific commands and outputs. No vagues plans like "ci passed" or "tested on my machine" -->
+<!-- What steps you've taken to check your work? Include specific commands and outputs. No vague plans like "ci passed" or "tested on my machine" -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Delete this notice and replace it with your PR description:
+<!-- Delete this entire notice and replace it with your PR description:
 Describe the reasons for the changes (WHY), and summarize the changes in behavior (WHAT).
 What steps you've taken to check your work? Include specific commands and outputs. No vague test plans like "ci passed" or "tested on my machine".
 The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->


### PR DESCRIPTION
Different people have different ideas about what should go into a PR description.
Sometimes, descriptions are brief and assume extra, non-public context—such as internal Slack conversations or prior meetings.

This can make it challenging for us in support to understand what was changed and why when investigating past changes.

Should we establish some guidelines for PR descriptions and apply a default template across all our orgs?

Note: **Any repo can override the org-wide default by providing a pull_request_template.md file. Currently, [six repos](https://github.com/search?q=%28org%3Asynadia-io+OR+org%3Asynadia-labs+OR++org%3AConnectEverything+OR+org%3Anats-io%29+pull_request_template.md&type=code) have a template.**
[19 repos](https://github.com/search?q=%28org%3Asynadia-io+OR+org%3Asynadia-labs+OR++org%3AConnectEverything+OR+org%3Anats-io%29+path%3Acontributing.md&type=code) have contributing.md file